### PR TITLE
Force new files to be created before we write to them

### DIFF
--- a/UKHO.ChromeDriver.BinarySync/Functions/Save-ChromeDriverBinaries.ps1
+++ b/UKHO.ChromeDriver.BinarySync/Functions/Save-ChromeDriverBinaries.ps1
@@ -30,13 +30,18 @@ function Save-ChromeDriverBinaries {
         $latestReleases | ForEach-Object {
             $fileName = Join-Path $TargetDirectory $_.ChromeVersion
             Write-Output "Downloading: $fileName"
+            # We need to create the file before we write to it else it doesn't work with PSDrives
+            if (-not (Test-Path -Path $fileName -PathType Leaf)) {
+                New-Item -Path $fileName -ItemType File -Force | Out-Null
+            }
             Set-Content -Path $fileName -Value $_.ChromeDriverVersion
             $ChromeDriverVersion = $_.ChromeDriverVersion
             $chromeDriverFiles | Where-Object { $_.Key -like "$ChromeDriverVersion*" } | ForEach-Object {
                 $fileName = Join-Path $TargetDirectory $_.Key
                 if (-not (Test-Path -Path $fileName -PathType Leaf)) {
-                    New-Item -ItemType Directory -Force -Path (Split-Path $fileName) | Out-Null
                     Write-Output "Downloading: $fileName"
+                    # We need to create the file before we write to it else it doesn't work with PSDrives
+                    New-Item -Path $fileName -ItemType File -Force | Out-Null
                     $webClient.Downloadfile("$DownloadRootUrl$($_.Key)", $fileName)
                 }
             }


### PR DESCRIPTION
Using credentials with a mounted PSDrive was causing files to not be created and exceptions to be thrown